### PR TITLE
adjust "import simplejson" to "import josn"

### DIFF
--- a/zapi.py
+++ b/zapi.py
@@ -7,9 +7,9 @@
 ################################################
 
 try:
-    import json
-except ImportError:
     import simplejson as json
+except ImportError:
+    import json
 
 import urllib2, subprocess, re, time
 


### PR DESCRIPTION
In Python 2.6+, simplejson is replace by josn, so adjust "import json" to default, if import error, import simplejson
